### PR TITLE
Checkbox fixes

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -100,8 +100,8 @@
 
 {% block checkbox_row %}
     {% spaceless %}
-        <div class="checkbox">
-            <label>
+        <div class="checkbox {% if errors is not empty %}has-error{% endif %}">
+            <label class="control-group">
                 {{ form_widget(form) }}
                 {{ form.vars.label|trans({}, translation_domain) }}
             </label>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -103,7 +103,7 @@
         <div class="checkbox">
             <label>
                 {{ form_widget(form) }}
-                {{ form_label(form) }}
+                {{ form.vars.label|trans({}, translation_domain) }}
             </label>
         </div>
     {% endspaceless %}


### PR DESCRIPTION
Currently, the `checkbox_row` block nests a label inside a label, which is against HTML standards.  There is also no way to tell if a checkbox has an error (such as when you require one to be checked for TOS acceptance) without using error_bubbling on your form.  This PR introduces a fix for both of these issues.
